### PR TITLE
OAI-46: Added docker configuration allowing creation of standalone claim-ai server instance

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,34 @@
+FROM python:3.7-stretch
+ENV PYTHONUNBUFFERED 1
+ENV REMOTE_USER_AUTHENTICATION false
+ENV ROW_SECURITY true
+ENV DEBUG false
+RUN apt-get update && apt-get install -y apt-transport-https ca-certificates gettext
+RUN apt-get update
+RUN apt-get install -y python3-dev unixodbc-dev
+RUN apt-get install git
+RUN pip install --upgrade pip
+
+RUN mkdir /openimis-be-claim_ai_py
+COPY . /openimis-be-claim_ai_py
+
+# --- For prod
+RUN git clone https://github.com/openimis/openimis-be_py/
+RUN mv openimis-be_py openimis-be
+WORKDIR /openimis-be
+RUN git checkout develop
+# --- For local testing 
+# RUN mv ./openimis-be-claim_ai_py/openimis-be_py openimis-be
+# WORKDIR /openimis-be
+
+RUN cp ../openimis-be-claim_ai_py/openimis.json openimis.json
+
+RUN pip install -r requirements.txt
+RUN python modules-requirements.py openimis.json > modules-requirements.txt
+RUN pip install -r modules-requirements.txt
+WORKDIR /openimis-be/openIMIS
+RUN NO_DATABASE=True python manage.py compilemessages
+RUN NO_DATABASE=True python manage.py collectstatic --clear --noinput
+ENTRYPOINT ["/openimis-be/script/entrypoint.sh"]
+# CMD ["/openimis-be/script/entrypoint.sh"]
+#ENTRYPOINT ["/bin/sh"]

--- a/claim_ai/evaluation/converters/claim.py
+++ b/claim_ai/evaluation/converters/claim.py
@@ -11,7 +11,7 @@ class ClaimConverter(AbstractConverter):
     def to_ai_input(self, claim):
         claim_inputs_for_items = defaultdict(lambda: {})
 
-        for item in claim['item']:
+        for item in claim.get('item', []):
             item_type = item['extension'][0]['url']
             item_id = self._get_item_id_by_product_service(claim, item_type, item['productOrService']['text'])
             claim_item_id = item['extension'][0]['valueReference']['identifier']['value']

--- a/claim_ai/module_config.json
+++ b/claim_ai/module_config.json
@@ -1,0 +1,7 @@
+{
+  "authentication": [],
+  "claim_response_url": "http://localhost:8000/claim_ai/ClaimResponse",
+  "ai_model_file": "",
+  "claim_response_organization": "openIMIS-Claim-AI",
+  "date_format": "%Y-%m-%d"
+}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -25,7 +25,8 @@ services:
       context: ../openimis-be-claim_ai_py
     command: start_asgi
     environment:
-      - SIMPLE_DATABASE=True
+      - NO_DATABASE_ENGINE=True
+      - NO_DATABASE=True
       - CHANNELS_HOST=amqp://guest:guest@127.0.0.1/
       - REMOTE_USER_AUTHENTICATION=True
       - DEBUG=True
@@ -35,7 +36,6 @@ services:
       - WSGI_APP=False
       - ASGI_APP=True
       - ASGI_PORT=8001
-      - NO_DATABASE=True
     networks:
       - openimis-net
     ## WARNING:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,48 @@
+version: "2.4"
+
+services:
+  rabbitmq:
+    container_name: openimis-rabbitmq
+    # 3-management is the 3.x version including the admin interface. For a barebones image, use 3-alpine
+    image: rabbitmq:3-management
+    networks:
+      - openimis-net
+    ## WARNING:
+    ## exposing the frontend port outside the openimis-net network
+    ## may lead to security issue (depending on your network topology)
+    ports:
+      # Management port, default credentials: guest/guest
+      - 15672:15672
+      # Other RabbitMQ ports
+      - 5672:5672
+      #- 6379:6379
+      - 4369:4369
+  claim-ai:
+    ##restart: always
+    platform: linux
+    container_name: openimis-claim-ai
+    build:
+      context: ../openimis-be-claim_ai_py
+    command: start_asgi
+    environment:
+      - SIMPLE_DATABASE=True
+      - CHANNELS_HOST=amqp://guest:guest@127.0.0.1/
+      - REMOTE_USER_AUTHENTICATION=True
+      - DEBUG=True
+      - ROW_SECURITY=False
+      - SITE_ROOT=api
+      - CELERY_BROKER_URL=amqp://rabbitmq
+      - WSGI_APP=False
+      - ASGI_APP=True
+      - ASGI_PORT=8000
+      - NO_DATABASE=True
+    networks:
+      - openimis-net
+    ## WARNING:
+    ## exposing the backend port outside the openimis-net network
+    ## may lead to security issue (depending on your network topology)
+    ports:
+      - 8001:8001
+
+networks:
+  openimis-net:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -34,7 +34,7 @@ services:
       - CELERY_BROKER_URL=amqp://rabbitmq
       - WSGI_APP=False
       - ASGI_APP=True
-      - ASGI_PORT=8000
+      - ASGI_PORT=8001
       - NO_DATABASE=True
     networks:
       - openimis-net

--- a/openimis.json
+++ b/openimis.json
@@ -1,0 +1,12 @@
+{
+  "modules": [
+    {
+      "name": "core",
+      "pip": "openimis-be-core==1.2.0rc4"
+    },
+    {
+      "name": "claim_ai",
+      "pip": "-e ./../openimis-be-claim_ai_py"
+    }
+  ]
+}


### PR DESCRIPTION
TICKET: [OAI-46](https://openimis.atlassian.net/secure/RapidBoard.jspa?rapidView=28&projectKey=OAI&modal=detail&selectedIssue=OAI-46)

Note: 
By default server runs on port 8001 instead of 8000 for avoiding conflicts with other openimis instances
Currently backend develop branch is used as application base (changes introduced in [this PR](https://github.com/openimis/openimis-be_py/pull/30) are required. 
If claim-ai is run as standalone instance configuration from JSON file is used. If claim-ai is added as openimis module, config is loaded from database.
RabbitMQ is used as message broker