### PR TITLE
Added docker setup to README, docker-compose use env variables 

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,27 @@ It is dedicated to be deployed as a module of [openimis-be_py](https://github.co
 ## ORM mapping:
 None
 
+## Docker Setup:
+For setting up dockerized instance `.env` file have to be added to openimis-be-claim_ai_py.
+* env file must provide following variables:
+  ```
+  CHANNELS_HOST=<rabbitmq host used by channels layer>
+  ASGI_PORT=<Port on which the application is available>
+  ```
+  * If local instance of rabbitmq is used then `amqp://guest:guest@127.0.0.1/` can be used as CHANNELS HOST.
+  
+In openimis-be-claim_ai_py directory files regarding model evaluation - Scaler, Encoder and Model 
+have to be added.
+By default, expected file names are:
+- Scaler.obj
+- Encoder.obj
+- joblib_Voting_Model.pkl
+
+Used files can be changed by adjusting variables in `module_config.json`.
+For the default files a hot reload is applied. If files other than defaults are used, 
+hot reload can be added by adjusting `volume` paths in `claim-ai` service in docker-compose.
+
+
 ## Listened Django Signals
 None
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -27,22 +27,20 @@ services:
     environment:
       - NO_DATABASE_ENGINE=True
       - NO_DATABASE=True
-      - CHANNELS_HOST=amqp://guest:guest@127.0.0.1/
-      - REMOTE_USER_AUTHENTICATION=True
-      - DEBUG=True
-      - ROW_SECURITY=False
-      - SITE_ROOT=api
-      - CELERY_BROKER_URL=amqp://rabbitmq
       - WSGI_APP=False
       - ASGI_APP=True
-      - ASGI_PORT=8001
+      - SITE_ROOT=api
+      - CELERY_BROKER_URL=amqp://rabbitmq
+
+      - CHANNELS_HOST=${CHANNELS_HOST}
+      - ASGI_PORT=${ASGI_PORT}
     networks:
       - openimis-net
     ## WARNING:
     ## exposing the backend port outside the openimis-net network
     ## may lead to security issue (depending on your network topology)
     ports:
-      - 8001:8001
+      - ${ASGI_PORT}:${ASGI_PORT}
     volumes: 
       - "./scaler.pkl:/openimis-be-claim_ai_py/scaler.pkl"
       - "./Encoder.obj:/openimis-be-claim_ai_py/Encoder.obj"


### PR DESCRIPTION
Changes: 
- Added 'Docker Setup' point to README
- Remove unnecessary variables from docker-compose 
- CHANNELS_HOST and ASGI_PORT don't have default values and needs to be set through .env file